### PR TITLE
Changed listener to use event delegation.

### DIFF
--- a/feature-comments.js
+++ b/feature-comments.js
@@ -7,7 +7,7 @@ function featured_comments_click() {
 	jQuery('.feature-comments').unbind('click');
 	
 	// rebind
-	jQuery('.feature-comments').click(function(){
+	jQuery('.wrap').on('click', '.feature-comments', function(){
 		$this = jQuery(this);
 		jQuery.post (
 			featured_comments.ajax_url,


### PR DESCRIPTION
I modified the `click` event listener to use event delegation so that it will work on pages where the comments meta box is loaded after this script. This will allow the plugin's feature to be used from post edit views if the comments are visible.

More specifically, I needed to provide this functionality on the WooCommerce Product edit pages so the client can choose featured reviews directly from that view. This change has been tested on the Comments edit page and the Products edit page. 